### PR TITLE
Use user $SHELL to run commands rather than bash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,7 +323,7 @@ dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -582,6 +588,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,7 +871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -933,6 +967,15 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1160,8 +1203,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "multitask"
-version = "0.37.2"
+version = "0.38.2"
 dependencies = [
  "zellij-tile",
 ]
@@ -1415,6 +1464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.0.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1572,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1612,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1758,7 +1881,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
@@ -2170,7 +2293,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 
@@ -2435,6 +2558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.37.2"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7c93e10683f2a81cfbbcfd005765c68eadc2b8d9aa24e091e71e03ce2a40d0"
+checksum = "23245bbef7a6dd1c6e44a73b697fcd4b15eac5d0812dfee4b633ae425c8c1ba3"
 dependencies = [
  "clap",
  "serde",
@@ -2622,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "zellij-utils"
-version = "0.37.2"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c043465af8187811927bb5f4c2863aece71081a355e8616fa6d00892eedba2"
+checksum = "d2c255271eab3868f67bb0efa4d0af5bf0aa2ddbedd3b79a83fc258c1e57e15a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2648,6 +2782,8 @@ dependencies = [
  "notify-debouncer-full",
  "once_cell",
  "percent-encoding",
+ "prost",
+ "prost-build",
  "regex",
  "rmp-serde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "multitask"
-version = "0.37.2"
+version = "0.38.1"
 authors = ["Aram Drevekenin <aram@poor.dev>"]
 edition = "2018"
 
 [dependencies]
-zellij-tile = "0.37.2"
+zellij-tile = "0.38.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "multitask"
-version = "0.38.1"
+version = "0.38.2"
 authors = ["Aram Drevekenin <aram@poor.dev>"]
 edition = "2018"
 
 [dependencies]
-zellij-tile = "0.38.1"
+zellij-tile = "0.38.2"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ echo "so will I!"
 ## Installation
 1. Download the `multitask.wasm` file from the release matching your installed Zellij version
 2. Place it in `~/zellij-plugins`
-3. From within Zellij, run `zellij action start-or-reload-plugin file:~/zellij-plugins/multitask.wasm`
+3. From within Zellij, run `zellij action start-or-reload-plugin file:~/zellij-plugins/multitask.wasm --configuration "shell=$SHELL"`
 
 ## Development
 

--- a/dev.kdl
+++ b/dev.kdl
@@ -14,13 +14,7 @@ layout {
                     // if you have "watchexec" installed, you can comment the above line and uncomment the below one to build + reload the plugin on fs changes
                     // args "-c" "watchexec 'cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/multitask.wasm'"
                 }
-                pane expanded=true {
-                    plugin location="file:target/wasm32-wasi/debug/multitask.wasm"
-                }
             }
         }
-    }
-    pane size=2 borderless=true {
-        plugin location="zellij:status-bar"
     }
 }

--- a/dev.kdl
+++ b/dev.kdl
@@ -10,7 +10,7 @@ layout {
             }
             pane stacked=true {
                 pane size="10%" command="bash" name="COMPILE AND RELOAD PLUGIN" {
-                    args "-c" "cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/multitask.wasm"
+                    args "-c" "cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/multitask.wasm --configuration \"shell=$SHELL\""
                     // if you have "watchexec" installed, you can comment the above line and uncomment the below one to build + reload the plugin on fs changes
                     // args "-c" "watchexec 'cargo build && zellij action start-or-reload-plugin file:target/wasm32-wasi/debug/multitask.wasm'"
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,14 +24,12 @@ struct State {
     plugin_id: Option<u32>,
 }
 
-register_plugin!(State);
-
 impl ZellijPlugin for State {
     fn load(&mut self, _: BTreeMap<String, String>) {
         request_permission(&[PermissionType::ReadApplicationState, PermissionType::ChangeApplicationState, PermissionType::RunCommands, PermissionType::OpenFiles, PermissionType::OpenTerminalsOrPlugins]);
         subscribe(&[EventType::PaneUpdate, EventType::FileSystemUpdate, EventType::FileSystemDelete, EventType::Key]);
         self.plugin_id = Some(get_plugin_ids().plugin_id);
-        self.multitask_file = PathBuf::from(".multitask");
+        self.multitask_file = PathBuf::from("/host").join(".multitask");
         show_self(true);
     }
 
@@ -169,3 +167,5 @@ impl State {
         return false;
     }
 }
+
+register_plugin!(State);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct State {
 
 impl ZellijPlugin for State {
     fn load(&mut self, config: BTreeMap<String, String>) {
-        request_permission(&[PermissionType::ReadApplicationState, PermissionType::ChangeApplicationState, PermissionType::RunCommands, PermissionType::OpenFiles, PermissionType::OpenTerminalsOrPlugins]);
+        request_permission(&[PermissionType::ReadApplicationState, PermissionType::ChangeApplicationState, PermissionType::RunCommands, PermissionType::OpenFiles]);
         subscribe(&[EventType::PaneUpdate, EventType::FileSystemUpdate, EventType::FileSystemDelete, EventType::Key]);
         self.plugin_id = Some(get_plugin_ids().plugin_id);
         self.multitask_file = PathBuf::from("/host").join(".multitask");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ mod parallel_tasks;
 mod multitask_file;
 use zellij_tile::prelude::*;
 
-
 use std::collections::{VecDeque, BTreeMap};
+
 use std::path::PathBuf;
 use std::time::{Instant, Duration};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,8 @@ mod parallel_tasks;
 mod multitask_file;
 use zellij_tile::prelude::*;
 
-use std::collections::VecDeque;
+
+use std::collections::{VecDeque, BTreeMap};
 use std::path::PathBuf;
 use std::time::{Instant, Duration};
 
@@ -26,7 +27,8 @@ struct State {
 register_plugin!(State);
 
 impl ZellijPlugin for State {
-    fn load(&mut self) {
+    fn load(&mut self, _: BTreeMap<String, String>) {
+        request_permission(&[PermissionType::ReadApplicationState, PermissionType::ChangeApplicationState, PermissionType::RunCommands, PermissionType::OpenFiles, PermissionType::OpenTerminalsOrPlugins]);
         subscribe(&[EventType::PaneUpdate, EventType::FileSystemUpdate, EventType::FileSystemDelete, EventType::Key]);
         self.plugin_id = Some(get_plugin_ids().plugin_id);
         self.multitask_file = PathBuf::from(".multitask");
@@ -65,7 +67,12 @@ impl State {
     pub fn start_current_tasks(&mut self) {
         if let Some(running_tasks) = &self.running_tasks {
             for task in &running_tasks.run_tasks {
-                open_command_pane_floating(&task.command, task.args.iter().map(|a| a.as_str()).collect());
+                let cmd = CommandToRun {
+                    path: (&task.command).into(), 
+                    args: task.args.clone(),
+                    cwd: None
+                };
+                open_command_pane_floating(cmd);
             }
         }
     }
@@ -73,13 +80,13 @@ impl State {
         if let Some(running_tasks) = self.running_tasks.as_ref() {
             for task in &running_tasks.run_tasks {
                 if let Some(terminal_pane_id) = task.terminal_pane_id {
-                    focus_terminal_pane(terminal_pane_id as i32, true);
+                    focus_terminal_pane(terminal_pane_id as u32, true);
                     toggle_pane_embed_or_eject();
                     self.completed_task_ids.push(terminal_pane_id);
                 }
             }
             if let Some(edit_pane_id) = self.edit_pane_id {
-                focus_terminal_pane(edit_pane_id as i32, false);
+                focus_terminal_pane(edit_pane_id as u32, false);
             }
         }
         self.running_tasks = None;
@@ -95,7 +102,7 @@ impl State {
         }
         all_tasks.append(&mut self.completed_task_ids.drain(..).collect());
         for pane_id in all_tasks {
-            close_terminal_pane(pane_id as i32);
+            close_terminal_pane(pane_id as u32);
         }
         self.running_tasks = None;
         self.completed_task_ids = vec![];

--- a/src/multitask_file.rs
+++ b/src/multitask_file.rs
@@ -13,7 +13,7 @@ pub fn create_file_with_text(path: &Path, text: &str) {
     };
 }
 
-pub fn parse_multitask_file(filename: PathBuf) -> Result<Vec<ParallelTasks>, std::io::Error> {
+pub fn parse_multitask_file(filename: PathBuf, shell: &str) -> Result<Vec<ParallelTasks>, std::io::Error> {
     let stringified_file = std::fs::read_to_string(filename)?;
     let mut parallel_tasks = vec![];
     let mut current_tasks = vec![];
@@ -22,7 +22,7 @@ pub fn parse_multitask_file(filename: PathBuf) -> Result<Vec<ParallelTasks>, std
         let line = line.to_string();
         let line_is_empty = line.trim().is_empty();
         if !line.starts_with("#") && !line_is_empty {
-            let task = RunTask::from_file_line(&line, current_step);
+            let task = RunTask::from_file_line(shell, &line, current_step);
             current_tasks.push(task);
         } else if line_is_empty && !current_tasks.is_empty() {
             parallel_tasks.push(ParallelTasks::new(current_tasks.drain(..).collect()));

--- a/src/parallel_tasks.rs
+++ b/src/parallel_tasks.rs
@@ -44,7 +44,7 @@ impl ParallelTasks {
                         if task.terminal_pane_id.is_none() {
                             task.mark_pane_id(pane.id);
                             if let Some(title) = &task.title {
-                                rename_terminal_pane(pane.id as i32, title);
+                                rename_terminal_pane(pane.id as u32, title);
                             }
                         }
                         if !task.is_complete() && pane.exited {

--- a/src/parallel_tasks.rs
+++ b/src/parallel_tasks.rs
@@ -76,8 +76,8 @@ impl RunTask {
             ..Default::default()
         }
     }
-    pub fn from_file_line(file_line: &str, step_number: usize) -> Self {
-        Self::new(vec!["bash", "-c", file_line])
+    pub fn from_file_line(shell: &str, file_line: &str, step_number: usize) -> Self {
+        Self::new(vec![shell, "-c", file_line])
             .pane_title(format!("STEP {} - {}", step_number, file_line))
     }
     pub fn pane_title(mut self, title: String) -> Self {


### PR DESCRIPTION
* Update plugin code so it works with 0.38.2.
* Using the new plugin configuration, the user can set the shell used to run the scripts. A good way to do this is by just using `$SHELL`, i.e., the user's default shell. 
  * I believe this addresses #1.