### PR TITLE
Running commands from provided cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ echo "so will I!"
 ## Installation
 1. Download the `multitask.wasm` file from the release matching your installed Zellij version
 2. Place it in `~/zellij-plugins`
-3. From within Zellij, run `zellij action start-or-reload-plugin file:~/zellij-plugins/multitask.wasm --configuration "shell=$SHELL"`
+3. From within Zellij, run ``zellij action launch-or-focus-plugin file:~/zellij-plugins/multitask.wasm --configuration "shell=$SHELL,cwd=`pwd`"``
 
 ## Development
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ struct State {
     is_hidden: bool,
     plugin_id: Option<u32>,
     shell: String,
+    cwd: Option<PathBuf>,
 }
 
 impl ZellijPlugin for State {
@@ -34,6 +35,10 @@ impl ZellijPlugin for State {
         self.shell = match config.get("shell") {
             Some(s) => String::from(s),
             _ => String::from("bash")
+        };
+        self.cwd = match config.get("cwd") {
+            Some(s) => Some(PathBuf::from(s)),
+            _ => None
         };
         show_self(true);
     }
@@ -73,7 +78,7 @@ impl State {
                 let cmd = CommandToRun {
                     path: (&task.command).into(), 
                     args: task.args.clone(),
-                    cwd: None
+                    cwd: self.cwd.clone()
                 };
                 open_command_pane_floating(cmd);
             }


### PR DESCRIPTION
Run commands from a user-provided `cwd` (via the plugin configuration) rather than `/host`. Using something like ``cwd=`pwd` `` in the configuration means the command will run in the directory that `multitask` was invoked in.

Closes #5.